### PR TITLE
Resolve negative counts in paginationStore

### DIFF
--- a/.changeset/dry-mice-tap.md
+++ b/.changeset/dry-mice-tap.md
@@ -1,0 +1,5 @@
+---
+'@layerstack/svelte-stores': patch
+---
+
+Resolve negative counts in paginationStore

--- a/packages/svelte-stores/src/lib/paginationStore.ts
+++ b/packages/svelte-stores/src/lib/paginationStore.ts
@@ -50,7 +50,7 @@ function createState(_page: number, perPage: number, total: number) {
     page,
     perPage,
     total,
-    from: Math.min(total, (page - 1) * perPage + 1),
+    from: Math.min(total, Math.max(0, (page - 1) * perPage + 1)),
     to: Math.min(total, page * perPage),
 
     totalPages,


### PR DESCRIPTION
Resolve a bug causing negative counts in paginationStore when there are fewer items than the per page count

![](https://github.com/user-attachments/assets/0481b957-4399-4128-b684-b3f7f9362584)