### PR TITLE
fix(themeStore): Only manage system dark mode (`<html class="dark">`) if there are any dark themes defined

### DIFF
--- a/.changeset/fresh-worlds-retire.md
+++ b/.changeset/fresh-worlds-retire.md
@@ -1,0 +1,5 @@
+---
+'@layerstack/svelte-stores': patch
+---
+
+fix(themeStore): Only manage system dark mode (`<html class="dark">`) if there are any dark themes defined

--- a/packages/svelte-stores/src/lib/themeStore.ts
+++ b/packages/svelte-stores/src/lib/themeStore.ts
@@ -48,10 +48,13 @@ export function createThemeStore(options: ThemeStoreOptions): ThemeStore {
   let darkMatcher = window.matchMedia('(prefers-color-scheme: dark)');
 
   function resolveSystemTheme({ matches }: { matches: boolean }) {
-    if (matches && options.dark.length) {
-      document.documentElement.classList.add('dark');
-    } else {
-      document.documentElement.classList.remove('dark');
+    // Only manage dark mode (`<html class="dark">`) if there are any dark themes defined
+    if (options.dark.length) {
+      if (matches) {
+        document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
+      }
     }
 
     store.set(new CurrentTheme(null, matches));


### PR DESCRIPTION



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
